### PR TITLE
handle exceptions and return meaningful responses to clients.

### DIFF
--- a/src/main/java/com/job_seeker/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/job_seeker/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.job_seeker.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<String> handleResourceNotFoundException(ResourceNotFoundException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<String> handleInvalidRequestException(InvalidRequestException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleGenericException(Exception ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/job_seeker/model/Application.java
+++ b/src/main/java/com/job_seeker/model/Application.java
@@ -35,5 +35,10 @@ public class Application {
     @Enumerated(EnumType.STRING)
     @Column(name = "status",nullable = false)
     private Status status;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = new Timestamp(System.currentTimeMillis());
+    }
 }
 


### PR DESCRIPTION
You should use @ControllerAdvice to catch and handle exceptions effectively. Without it, exceptions are logged in the terminal but are not returned to the client, leaving the client unaware of the issue. By using @ControllerAdvice, you can ensure that exceptions are appropriately handled and communicated. You can test this functionality yourself to observe the difference